### PR TITLE
Add invite resend and restrict user list access

### DIFF
--- a/app/templates/user_list.html
+++ b/app/templates/user_list.html
@@ -65,7 +65,9 @@
         <td>{{ invite.role }}</td>
         <td>—</td>
         <td><span class="badge bg-secondary">Pending Invite</span></td>
-        <td><small>Sent</small></td>
+        <td>
+          <a href="{{ url_for('register_routes.resend_invite', invite_id=invite.id) }}" class="btn btn-sm btn-secondary">Resend</a>
+        </td>
       </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- allow only SuperXuser or Admin roles to view the user list and create users
- add a route to resend pending invitations
- show a `Resend` button in the user list

## Testing
- `python -m py_compile app/routes/register_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6863b1bdeb008323b11a52c14d2b7612