### PR TITLE
Allow custom admin URI for tenant DB creation

### DIFF
--- a/README
+++ b/README
@@ -95,6 +95,12 @@ database.
 When this variable is unset the application falls back to the local
 ``instance/app.db`` SQLite file for development.
 
+When running on MySQL the helper that creates tenant databases looks for a
+``SQLALCHEMY_ADMIN_URI`` environment variable.  If set, this URI is used for
+admin operations such as ``CREATE DATABASE``.  It should reference a user with
+permissions to create new databases.  If unset, the main
+``SQLALCHEMY_DATABASE_URI`` value is used instead.
+
 ## Purchase numbers for invoice lines
 
 Invoice line items automatically receive a unique purchase number once

--- a/app/utils/database_utils.py
+++ b/app/utils/database_utils.py
@@ -1,7 +1,7 @@
 import os
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy.engine.url import make_url
+from sqlalchemy.engine.url import make_url, URL
 from app import db
 from app.models import Base, TenantUser, TenantOTP, TenantUserInvite, Customer  # Ensure all models are imported!
 
@@ -17,21 +17,26 @@ COMPANY_DATABASES = {}  # domain => scoped_session instance
 
 
 def _use_mysql():
-    """Return ``True`` when the main database engine uses MySQL."""
+    """Return ``True`` when the application is configured for MySQL."""
     try:
         return db.engine.url.drivername.startswith("mysql")
     except Exception:
-        uri = os.environ.get("SQLALCHEMY_DATABASE_URI", "")
-        return uri.startswith("mysql")
-    """Return True if the main DB URI points to MySQL."""
+        pass
+
     uri = os.environ.get("SQLALCHEMY_DATABASE_URI", "")
     return uri.startswith("mysql")
+
+
+def _get_admin_base_url() -> URL:
+    """Return the SQLAlchemy URL used for admin-level operations."""
+    admin_uri = os.environ.get("SQLALCHEMY_ADMIN_URI")
+    uri = admin_uri or os.environ.get("SQLALCHEMY_DATABASE_URI")
+    return make_url(uri).set(database=None)
 
 
 def get_tenant_db_uri(domain: str) -> str:
     """Return the full SQLAlchemy URI for a tenant database."""
     if _use_mysql():
-        base_url = db.engine.url
         base_url = make_url(os.environ["SQLALCHEMY_DATABASE_URI"])
         db_name = domain.replace(".", "_")
         return str(base_url.set(database=db_name))
@@ -49,13 +54,11 @@ def get_tenant_db_path(domain):
 def create_company_schema(domain):
     """Create the tenant schema and return a scoped session factory."""
     if _use_mysql():
-        base_url = db.engine.url
-        base_url = make_url(os.environ["SQLALCHEMY_DATABASE_URI"])
+        base_url = _get_admin_base_url()
         db_name = domain.replace(".", "_")
 
         # Ensure the database exists before creating tables
-        admin_url = str(base_url.set(database=None))
-        admin_engine = create_engine(admin_url)
+        admin_engine = create_engine(str(base_url))
         with admin_engine.connect() as conn:
             conn.execute(text(f"CREATE DATABASE IF NOT EXISTS `{db_name}`"))
 
@@ -79,7 +82,6 @@ def get_db_for_domain(domain):
         return COMPANY_DATABASES[domain]
 
     if _use_mysql():
-        base_url = db.engine.url
         base_url = make_url(os.environ["SQLALCHEMY_DATABASE_URI"])
         db_name = domain.replace(".", "_")
         engine = create_engine(str(base_url.set(database=db_name)))


### PR DESCRIPTION
## Summary
- let `create_company_schema()` use a dedicated admin URI when creating tenant databases
- document the new `SQLALCHEMY_ADMIN_URI` env var
- clean up MySQL helpers

## Testing
- `pytest -q`
- `python -m py_compile app/utils/database_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6864d92205e48323b2318cc9eb4a6755