### PR TITLE
Add baseout footer and use in pre-dashboard templates

### DIFF
--- a/app/templates/baseout.html
+++ b/app/templates/baseout.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}My Accounting App{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="d-flex flex-column min-vh-100">
+  {% block content %}{% endblock %}
+  <footer class="bg-dark text-center text-white py-2 mt-auto">
+    <div>Copyright © 2025 abcdtech Limited UK. All rights reserved</div>
+  </footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/app/templates/forgot_password.html
+++ b/app/templates/forgot_password.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Forgot Password</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
+{% extends "baseout.html" %}
+{% block title %}Forgot Password{% endblock %}
+
+{% block content %}
   <div class="container mt-5">
     <div class="row justify-content-center">
       <div class="col-md-6">
@@ -41,6 +36,4 @@
       </div>
     </div>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Login</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
+{% extends "baseout.html" %}
+{% block title %}Login{% endblock %}
+
+{% block content %}
   <div class="container mt-5">
     <div class="row justify-content-center">
       <div class="col-md-6">
@@ -48,6 +43,4 @@
       </div>
     </div>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/register_company.html
+++ b/app/templates/register_company.html
@@ -1,13 +1,8 @@
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Register Company</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
+{% extends "baseout.html" %}
+{% block title %}Register Company{% endblock %}
+
+{% block content %}
   <div class="container mt-5">
     <div class="row justify-content-center">
       <div class="col-md-6">
@@ -49,6 +44,4 @@
       </div>
     </div>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/reset_otp.html
+++ b/app/templates/reset_otp.html
@@ -1,12 +1,8 @@
 <!-- templates/reset_otp.html -->
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Enter OTP</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
+{% extends "baseout.html" %}
+{% block title %}Enter OTP{% endblock %}
+
+{% block content %}
 <div class="container mt-5">
   <div class="row justify-content-center">
     <div class="col-md-6">
@@ -34,5 +30,4 @@
     </div>
   </div>
 </div>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/select_domain.html
+++ b/app/templates/select_domain.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head><title>Select Domain</title></head>
-<body>
+{% extends "baseout.html" %}
+{% block title %}Select Domain{% endblock %}
+
+{% block content %}
   <div class="container mt-5">
     <h3>Select your company domain</h3>
     <ul>
@@ -10,5 +10,4 @@
       {% endfor %}
     </ul>
   </div>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/set_new_password.html
+++ b/app/templates/set_new_password.html
@@ -1,11 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Set New Password</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
+{% extends "baseout.html" %}
+{% block title %}Set New Password{% endblock %}
+
+{% block content %}
 <div class="container mt-5">
   <div class="row justify-content-center">
     <div class="col-md-6">
@@ -33,5 +29,4 @@
     </div>
   </div>
 </div>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/validate_otp.html
+++ b/app/templates/validate_otp.html
@@ -1,12 +1,7 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Validate OTP</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body>
+{% extends "baseout.html" %}
+{% block title %}Validate OTP{% endblock %}
+
+{% block content %}
   <div class="container mt-5">
     <div class="row justify-content-center">
       <div class="col-md-6">
@@ -27,6 +22,4 @@
       </div>
     </div>
   </div>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add new `baseout.html` with copyright footer
- convert login and related pages to extend the new baseout

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686574e59cc08323870a0181618b3731