### PR TITLE
Fix env loading for mail defaults

### DIFF
--- a/README
+++ b/README
@@ -64,7 +64,9 @@ if __name__ == '__main__':
 
    `python main.py`.
 ## Environment variables
-Copy `env.example` to `.env` and set values for the following keys:
+Copy `env.example` to `.env` and set values for the following keys.  Older
+versions of the project used a file named just `env`; the application now
+loads `.env` by default but will fall back to `env` if present:
 - `SECRET_KEY`
 - `MAIL_USERNAME`
 - `MAIL_PASSWORD`

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,7 +14,15 @@ from dotenv import load_dotenv
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 INSTANCE_DIR = os.path.join(BASE_DIR, "instance")
 os.makedirs(INSTANCE_DIR, exist_ok=True)
-load_dotenv(os.path.join(BASE_DIR, '.env'))
+
+# Load environment variables from ".env".  Some older setups used a file
+# named just "env" so fall back to that if the new file does not exist.
+dotenv_path = os.path.join(BASE_DIR, ".env")
+if not os.path.exists(dotenv_path):
+    legacy_env = os.path.join(BASE_DIR, "env")
+    if os.path.exists(legacy_env):
+        dotenv_path = legacy_env
+load_dotenv(dotenv_path)
 
 db = SQLAlchemy()
 bcrypt = Bcrypt()


### PR DESCRIPTION
## Summary
- load environment variables from `.env` and fall back to `env`
- clarify env file usage in the README

## Testing
- `python -m py_compile app/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_686601d51cc883238c8eec86bd245b33