### PR TITLE
Add internal bank transfer

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -477,3 +477,21 @@ class SupplierPayment(Base):
     supplier = relationship('Supplier')
     journal_entry = relationship('JournalEntry')
 
+
+class BankTransfer(Base):
+    __tablename__ = 'bank_transfers'
+
+    id = Column(Integer, primary_key=True)
+    company_id = Column(Integer, nullable=False)
+    transfer_date = Column(Date, nullable=False)
+    from_cashbank_id = Column(Integer, ForeignKey('cash_bank.id'), nullable=False)
+    to_cashbank_id = Column(Integer, ForeignKey('cash_bank.id'), nullable=False)
+    amount = Column(Numeric(12, 2), nullable=False)
+    reference = Column(String(100))
+    narration = Column(String(255))
+    journal_entry_id = Column(Integer, ForeignKey('journal_entries.id'))
+
+    from_cashbank = relationship('CashBank', foreign_keys=[from_cashbank_id])
+    to_cashbank = relationship('CashBank', foreign_keys=[to_cashbank_id])
+    journal_entry = relationship('JournalEntry')
+

--- a/app/templates/accounting/bank_transfer.html
+++ b/app/templates/accounting/bank_transfer.html
@@ -1,0 +1,50 @@
+{% extends 'base.html' %}
+{% block title %}Bank Transfer{% endblock %}
+{% block content %}
+<h3>Internal Bank Transfer</h3>
+<form method="POST">
+  <div class="row g-3">
+    <div class="col-md-3">
+      <label>Date</label>
+      <input type="date" name="transfer_date" class="form-control" value="{{ current_date }}" required>
+    </div>
+    <div class="col-md-3">
+      <label>From Account</label>
+      <select name="from_account" class="form-select" required>
+        <option value="">-- Select --</option>
+        {% for cb in cash_banks %}
+        <option value="{{ cb.id }}">{{ cb.account_name or cb.bank_name or cb.wallet_name }} ({{ cb.type }})</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-md-3">
+      <label>To Account</label>
+      <select name="to_account" class="form-select" required>
+        <option value="">-- Select --</option>
+        {% for cb in cash_banks %}
+        <option value="{{ cb.id }}">{{ cb.account_name or cb.bank_name or cb.wallet_name }} ({{ cb.type }})</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-md-3">
+      <label>Amount</label>
+      <input type="number" step="0.01" name="amount" class="form-control" required>
+    </div>
+  </div>
+  <div class="row g-3 mt-2">
+    <div class="col-md-6">
+      <label>Reference</label>
+      <input type="text" name="reference" class="form-control">
+    </div>
+    <div class="col-md-6">
+      <label>Notes</label>
+      <input type="text" name="narration" class="form-control">
+    </div>
+  </div>
+  <div class="mt-3">
+    <button type="submit" class="btn btn-primary">Record Transfer</button>
+    <a href="{{ url_for('accounting_routes.bank_transfer_list') }}" class="btn btn-secondary">Cancel</a>
+  </div>
+</form>
+{% endblock %}
+

--- a/app/templates/accounting/bank_transfer_list.html
+++ b/app/templates/accounting/bank_transfer_list.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block title %}Bank Transfers{% endblock %}
+{% block content %}
+<h3>Bank Transfers</h3>
+<a href="{{ url_for('accounting_routes.bank_transfer') }}" class="btn btn-success mb-3">+ New Transfer</a>
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Reference</th>
+      <th>From Account</th>
+      <th>To Account</th>
+      <th class="text-end">Amount</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for t in transfers %}
+    <tr>
+      <td>{{ t.transfer_date }}</td>
+      <td>{{ t.reference }}</td>
+      <td>{{ t.from_cashbank.account_name or t.from_cashbank.bank_name or t.from_cashbank.wallet_name }}</td>
+      <td>{{ t.to_cashbank.account_name or t.to_cashbank.bank_name or t.to_cashbank.wallet_name }}</td>
+      <td class="text-end">{{ default_currency }} {{ '{:,.2f}'.format(t.amount) }}</td>
+    </tr>
+    {% else %}
+    <tr><td colspan="5" class="text-center text-muted">No transfers found.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -186,6 +186,8 @@
               <div class="accordion-body p-0">
                 <ul class="list-unstyled ms-3 my-2">
                   <li><a href="{{ url_for('accounting_routes.cash_bank_list') }}" class="d-block py-1">Bank and Cash</a></li>
+                  <li><a href="{{ url_for('accounting_routes.bank_transfer') }}" class="d-block py-1">Bank Transfer</a></li>
+                  <li><a href="{{ url_for('accounting_routes.bank_transfer_list') }}" class="d-block py-1">Transfer List</a></li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- model BankTransfer for tracking transfers between CashBank accounts
- record transfers using new `/bank-transfer` route
- list transfers at `/bank-transfers`
- include navigation links

## Testing
- `python -m py_compile app/routes/accounting_routes.py app/models/models.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686665e7c52c832397064b73ef8ec68f