### PR TITLE
Ensure fiscal year and company profile before using dashboard

### DIFF
--- a/app/routes/accounting_routes.py
+++ b/app/routes/accounting_routes.py
@@ -157,6 +157,12 @@ def chart_of_accounts():
         flash("❌ Company profile not found. Please complete company setup first.", "danger")
         return redirect(url_for('register_routes.profile_settings'))
 
+    # Ensure a fiscal year is configured
+    active_fy = tenant_session.query(FiscalYear).filter_by(company_id=company_id, is_closed=True).first()
+    if not active_fy:
+        flash("⚠️ Please configure a fiscal year before creating accounts.", "warning")
+        return redirect(url_for('accounting_routes.manage_fiscal_years'))
+
     # Seed account types if not initialized
     if not company.account_types_initialized:
         seed_default_account_types(tenant_session, company_id)


### PR DESCRIPTION
## Summary
- verify company profile and fiscal year before opening the dashboard
- guard Chart of Accounts page with fiscal year requirement

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^venv/')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68674137c4c083239622c2a005eceb8f