### PR TITLE
Fix debugger start for ssh environments

### DIFF
--- a/README
+++ b/README
@@ -132,6 +132,21 @@ the core tables:
 FLASK_APP=main.py flask db upgrade
 ```
 
+## Running with Gunicorn
+
+For production deployments you can serve the application using
+`gunicorn`. Bind the server to `0.0.0.0` so it accepts external
+connections and choose port `80` if you want the domain to work without
+a port suffix:
+
+```bash
+gunicorn --bind 0.0.0.0:80 main:app
+```
+
+Ports below ``1024`` require elevated privileges, so you may need to run
+the command with ``sudo`` or adjust your firewall rules if using a
+different port.
+
 ## Purchase numbers for invoice lines
 
 Invoice line items automatically receive a unique purchase number once

--- a/main.py
+++ b/main.py
@@ -9,4 +9,15 @@ migrate = Migrate(app, db)
 if __name__ == '__main__':
     with app.app_context():
         db.create_all()
-    app.run(debug=True)
+
+    # ``app.run`` defaults to enabling the debugger's automatic reloader
+    # when ``debug=True``.  In some SSH environments ``stdin`` is not a
+    # real TTY which causes Werkzeug's reloader to fail with a
+    # ``termios.error``.  Disable the reloader so the server starts
+    # reliably when launched remotely.
+    app.run(
+        host="0.0.0.0",  # allow external connections if the port is open
+        port=5000,
+        debug=True,
+        use_reloader=False,
+    )


### PR DESCRIPTION
## Summary
- disable Werkzeug's reloader so `termios` errors don't occur in remote shells
- listen on `0.0.0.0` for external connections
- document how to run the app with Gunicorn on port 80

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686804be2cc88323a155a598e30f9a5e