### PR TITLE
Remove SQLite fallback

### DIFF
--- a/README
+++ b/README
@@ -9,7 +9,7 @@ from sqlalchemy import text
 from flask import current_app
 
 # Step 1: Connect to central database (holding tenants list)
-CENTRAL_DB_URI = "sqlite:///instance/app.db"  # Replace with your actual main DB
+CENTRAL_DB_URI = "mysql+pymysql://<user>:<password>@<host>/<db>"
 
 def get_all_tenants():
     """Fetch tenants and their DB URIs from central tenant table"""
@@ -37,8 +37,7 @@ if __name__ == '__main__':
 ## Migrating to a tenant database
 
 1. Add each tenant domain to the `master_company` table. The migration
-   script uses the domain name to build the path of the SQLite database
-   under `tenant_dbs/`.
+   script uses the domain name to build the database name for each tenant.
 2. Run the migration script to apply Alembic upgrades for every tenant:
 
    ```bash
@@ -49,7 +48,7 @@ if __name__ == '__main__':
    to the latest revision before running the script:
 
    ```bash
-   FLASK_APP=main.py SQLALCHEMY_DATABASE_URI=sqlite:///tenant_dbs/<tenant>.db \
+   FLASK_APP=main.py SQLALCHEMY_DATABASE_URI=mysql+pymysql://<user>:<password>@<host>/<tenant_db> \
        flask db stamp head
    ```
 
@@ -104,8 +103,7 @@ database.
 
 
 
-When this variable is unset the application falls back to the local
-``instance/app.db`` SQLite file for development.
+
 
 When running on MySQL the helper that creates tenant databases looks for a
 ``SQLALCHEMY_ADMIN_URI`` environment variable.  If set, this URI is used for

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,12 +8,9 @@ import os
 from dotenv import load_dotenv
 
 
-# Absolute path to the repository root. This ensures that the default
-# SQLite database path is resolved correctly regardless of the current
-# working directory.
+# Absolute path to the repository root.  Used to locate the migrations
+# directory and the optional ``.env`` file.
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-INSTANCE_DIR = os.path.join(BASE_DIR, "instance")
-os.makedirs(INSTANCE_DIR, exist_ok=True)
 
 # Load environment variables from ".env".  Some older setups used a file
 # named just "env" so fall back to that if the new file does not exist.
@@ -35,14 +32,10 @@ def create_app(db_uri_override=None):
     app = Flask(__name__)
 
     # Main database config
-    # Default to the central database stored under ``instance/app.db`` unless
-    # overridden by an explicit URI or the ``SQLALCHEMY_DATABASE_URI``
-    # environment variable.
-    default_db_path = os.path.join(INSTANCE_DIR, 'app.db')
-    default_db = f"sqlite:///{default_db_path}"
-
     env_db = os.environ.get("SQLALCHEMY_DATABASE_URI")
-    app.config['SQLALCHEMY_DATABASE_URI'] = db_uri_override or env_db or default_db
+    app.config['SQLALCHEMY_DATABASE_URI'] = db_uri_override or env_db
+    if not app.config['SQLALCHEMY_DATABASE_URI']:
+        raise RuntimeError('SQLALCHEMY_DATABASE_URI must be configured')
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'your_secret_key_here')
     app.config['SESSION_TYPE'] = 'filesystem'

--- a/app/utils/database_utils.py
+++ b/app/utils/database_utils.py
@@ -16,17 +16,6 @@ BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 COMPANY_DATABASES = {}  # domain => scoped_session instance
 
 
-def _use_mysql():
-    """Return ``True`` when the application is configured for MySQL."""
-    try:
-        return db.engine.url.drivername.startswith("mysql")
-    except Exception:
-        pass
-
-    uri = os.environ.get("SQLALCHEMY_DATABASE_URI", "")
-    return uri.startswith("mysql")
-
-
 def _get_admin_base_url() -> URL:
     """Return the SQLAlchemy URL used for admin-level operations."""
     admin_uri = os.environ.get("SQLALCHEMY_ADMIN_URI")
@@ -35,42 +24,30 @@ def _get_admin_base_url() -> URL:
 
 def get_tenant_db_uri(domain: str) -> str:
     """Return the full SQLAlchemy URI for a tenant database."""
-    if _use_mysql():
-        base_url = make_url(os.environ["SQLALCHEMY_DATABASE_URI"])
-        db_name = domain.replace(".", "_")
-        return base_url.set(database=db_name).render_as_string(hide_password=False)
-    db_path = get_tenant_db_path(domain)
-    return f"sqlite:///{db_path}"
-
-
-
-
-def get_tenant_db_path(domain):
-    """Return the absolute path for a tenant's SQLite database."""
+    base_url = make_url(os.environ["SQLALCHEMY_DATABASE_URI"])
     db_name = domain.replace(".", "_")
-    return os.path.join(BASE_DIR, "tenant_dbs", f"{db_name}.db")
+    return base_url.set(database=db_name).render_as_string(hide_password=False)
+
+
+
+
 
 def create_company_schema(domain):
     """Create the tenant schema and return a scoped session factory."""
-    if _use_mysql():
-        base_url = _get_admin_base_url()
-        db_name = domain.replace(".", "_")
-        # Debug: print the admin URI being used
-        print(f"[DEBUG] ADMIN URI: {base_url}")
-        print(f"[DEBUG] Creating DB: {db_name}")
-        # Ensure the database exists before creating tables
-        admin_engine = create_engine(base_url.render_as_string(hide_password=False))
-        with admin_engine.connect() as conn:
-            conn.execute(text(f"CREATE DATABASE IF NOT EXISTS `{db_name}`"))
+    base_url = _get_admin_base_url()
+    db_name = domain.replace(".", "_")
+    # Debug: print the admin URI being used
+    print(f"[DEBUG] ADMIN URI: {base_url}")
+    print(f"[DEBUG] Creating DB: {db_name}")
+    # Ensure the database exists before creating tables
+    admin_engine = create_engine(base_url.render_as_string(hide_password=False))
+    with admin_engine.connect() as conn:
+        conn.execute(text(f"CREATE DATABASE IF NOT EXISTS `{db_name}`"))
 
-        engine = create_engine(
-            base_url.set(database=db_name).render_as_string(hide_password=False),
-            echo=True,
-        )
-    else:
-        db_path = get_tenant_db_path(domain)
-        os.makedirs(os.path.dirname(db_path), exist_ok=True)
-        engine = create_engine(f"sqlite:///{db_path}", echo=True)
+    engine = create_engine(
+        base_url.set(database=db_name).render_as_string(hide_password=False),
+        echo=True,
+    )
 
     Base.metadata.create_all(engine)
 
@@ -85,17 +62,11 @@ def get_db_for_domain(domain):
     if domain in COMPANY_DATABASES:
         return COMPANY_DATABASES[domain]
 
-    if _use_mysql():
-        base_url = make_url(os.environ["SQLALCHEMY_DATABASE_URI"])
-        db_name = domain.replace(".", "_")
-        engine = create_engine(
-            base_url.set(database=db_name).render_as_string(hide_password=False)
-        )
-    else:
-        db_path = get_tenant_db_path(domain)
-        if not os.path.exists(db_path):
-            raise Exception(f"No database found for domain: {db_path}")
-        engine = create_engine(f"sqlite:///{db_path}")
+    base_url = make_url(os.environ["SQLALCHEMY_DATABASE_URI"])
+    db_name = domain.replace(".", "_")
+    engine = create_engine(
+        base_url.set(database=db_name).render_as_string(hide_password=False)
+    )
 
     session_factory = scoped_session(sessionmaker(bind=engine))
     COMPANY_DATABASES[domain] = session_factory
@@ -104,11 +75,7 @@ def get_db_for_domain(domain):
 
 def get_company_db_session(domain):
     """Return a plain SQLAlchemy session bound to the tenant database."""
-    if _use_mysql():
-        print(f"[DEBUG] Tenant DB URI (OTP Validation): {get_tenant_db_uri(domain)}")
-    else:
-        db_path = get_tenant_db_path(domain)
-        print(f"[DEBUG] Tenant DB Session Path (OTP Validation): {db_path}")
+    print(f"[DEBUG] Tenant DB URI (OTP Validation): {get_tenant_db_uri(domain)}")
 
     session_factory = get_db_for_domain(domain)
     engine = session_factory.bind

--- a/env copy.example
+++ b/env copy.example
@@ -2,6 +2,6 @@
 SECRET_KEY=your-secret-key
 MAIL_USERNAME=your-email@example.com
 MAIL_PASSWORD=your-email-password
-SQLALCHEMY_DATABASE_URI=sqlite:///instance/app.db
+SQLALCHEMY_DATABASE_URI=mysql+pymysql://<user>:<password>@<host>/<db>
 SQLALCHEMY_ADMIN_URI=mysql+pymysql://<admin>:<password>@<host>/<db>
 DB_PASSWORD=your-database-password

--- a/notes.txt
+++ b/notes.txt
@@ -13,7 +13,7 @@ If migrations are re-initialized (e.g., you recreated the migrations
 folder), stamp each tenant database to the current revision before
 running the migration script:
 
-   FLASK_APP=main.py SQLALCHEMY_DATABASE_URI=sqlite:///tenant_dbs/<tenant>.db \
+   FLASK_APP=main.py SQLALCHEMY_DATABASE_URI=mysql+pymysql://<user>:<password>@<host>/<tenant_db> \
        flask db stamp head
 
 
@@ -22,9 +22,8 @@ Set the ``SQLALCHEMY_DATABASE_URI`` environment variable on the server to use
 your MySQL instance. For the provided credentials the value would be::
 
     mysql+pymysql://<user>:<password>@<host>/<db>
-If this variable is not set the application falls back to the default SQLite
-database for local testing.  ``notes.txt`` is only for developer reference and
-does not need to be deployed to production.
+``notes.txt`` is only for developer reference and does not need to be deployed
+to production.
 
 
 ## Resolving "no such column" errors

--- a/scripts/migrate_tenants.py
+++ b/scripts/migrate_tenants.py
@@ -6,7 +6,7 @@ from flask_migrate import Migrate, upgrade, stamp
 # Add parent directory to path so imports work
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from app import create_app, db  # ✅ FIXED
-from app.utils.database_utils import get_tenant_db_path, create_company_schema
+from app.utils.database_utils import get_tenant_db_uri, create_company_schema
 
 
 app = create_app()
@@ -18,9 +18,8 @@ BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 # an Alembic version, we stamp it with this revision before upgrading.
 BASE_REVISION = "df0745a851cf"
 
-# Point to the central database that stores tenant domains. The file
-# lives under the application's ``instance`` folder.
-CENTRAL_DB_URI = f"sqlite:///{os.path.join(BASE_DIR, 'instance', 'app.db')}"
+# Central database URI comes from the environment
+CENTRAL_DB_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
 
 
 def get_all_tenants():
@@ -31,12 +30,8 @@ def get_all_tenants():
 
 
 def migrate_tenant(domain):
-    db_path = get_tenant_db_path(domain)
-    if not os.path.exists(db_path):
-        # Ensure the tenant database exists before attempting migrations
-        create_company_schema(domain)
-
-    db_uri = f"sqlite:///{db_path}"
+    db_uri = get_tenant_db_uri(domain)
+    create_company_schema(domain)
     print(f"🔁 Migrating tenant: {domain}")
     app = create_app(db_uri_override=db_uri)
     migrations_dir = os.path.join(BASE_DIR, "migrations")


### PR DESCRIPTION
## Summary
- drop default SQLite database usage
- simplify tenant DB helpers for MySQL
- update migration script for MySQL databases
- refresh documentation and env example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68688b2769a08323bb9185c1895301c6