### PR TITLE
Display company ID on profile settings

### DIFF
--- a/app/templates/profile_settings.html
+++ b/app/templates/profile_settings.html
@@ -3,6 +3,7 @@
 
 {% block content %}
 <h3>Profile Settings</h3>
+<p class="text-muted">Company ID: {{ company.company_id if company else session.get('company_id') }}</p>
 
 {% set show_company = role in ['SuperXuser', 'Admin'] %}
 


### PR DESCRIPTION
## Summary
- show company ID at the top of profile settings page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868fe4264908323859a74c50c03bee6