### PR TITLE
Add GDS Tray listing and integrate with invoices

### DIFF
--- a/app/routes/accounting_routes.py
+++ b/app/routes/accounting_routes.py
@@ -21,6 +21,7 @@ from app.models.models import (
     Expense,
     SupplierPayment,
     BankTransfer,
+    Company,
 )
 from app.routes.register_routes import current_tenant_session
 from sqlalchemy import or_, and_, func
@@ -40,6 +41,8 @@ import uuid
 
 from app.utils.email_utils import send_email
 from app import mail
+import os
+import re
 
 
 
@@ -1947,6 +1950,51 @@ def generate_purchase_number(invoice_id: int, line_id: int) -> str:
     return f"P{invoice_id:04}{line_id:02}"
 
 
+def parse_airfile_metadata(path: str):
+    """Extract PNR and date from an AIR file."""
+    pnr = None
+    dt = None
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                if not pnr and line.startswith("MUC1A"):
+                    m = re.search(r"MUC1A\s+([A-Z0-9]{6})", line)
+                    if m:
+                        pnr = m.group(1)
+                if not dt and line.startswith("D-"):
+                    m = re.search(r"D-(\d{6})", line)
+                    if m:
+                        try:
+                            dt = datetime.strptime(m.group(1), "%y%m%d").date()
+                        except ValueError:
+                            dt = None
+                if pnr and dt:
+                    break
+    except OSError:
+        pass
+    return {"pnr": pnr, "date": dt}
+
+
+def list_airfiles(agent_code: str | None = None):
+    folder = os.path.join(current_app.root_path, "..", "airfiles")
+    files = []
+    if os.path.isdir(folder):
+        for name in os.listdir(folder):
+            if not name.lower().endswith(".air"):
+                continue
+            code = name.split("_")[0]
+            if agent_code and code != str(agent_code):
+                continue
+            meta = parse_airfile_metadata(os.path.join(folder, name))
+            files.append({
+                "agent_code": code,
+                "pnr": meta.get("pnr"),
+                "date": meta.get("date"),
+                "filename": name,
+            })
+    return files
+
+
 def get_supplier_balance(session, company_id, supplier):
     """Return payable balance for a supplier."""
     credit_total = session.query(func.coalesce(func.sum(JournalLine.credit), 0)).join(JournalEntry).filter(
@@ -2213,13 +2261,32 @@ def edit_invoice(invoice_id):
     ).all()
     staff_json = [{"email": s.email} for s in staff_list]
 
+    # Load GDS files for this company's code
+    company_core = Company.query.get(invoice.company_id)
+    agent_code = company_core.code if company_core else None
+    gds_files = list_airfiles(agent_code)
+
     return render_template(
         'accounting/invoice_edit.html',
         invoice=invoice,
         suppliers=suppliers,
         customers_json=customers_json,
         staff_json=staff_json,
+        gds_files=gds_files,
     )
+
+
+@accounting_routes.route('/invoices/<int:invoice_id>/create-from-airfiles', methods=['POST'])
+def create_invoice_from_airfiles(invoice_id):
+    if 'domain' not in session:
+        return redirect(url_for('register_routes.login'))
+
+    selected = request.form.getlist('airfiles')
+    if not selected:
+        flash('No files selected.', 'warning')
+    else:
+        flash('Selected files: ' + ', '.join(selected), 'info')
+    return redirect(url_for('accounting_routes.edit_invoice', invoice_id=invoice_id))
 
 
 

--- a/app/templates/accounting/invoice_edit.html
+++ b/app/templates/accounting/invoice_edit.html
@@ -3,6 +3,36 @@
 {% set locked = invoice.status == 'Finalised' %}
 {% block content %}
 <h3>Edit Invoice #{{ invoice.invoice_number }}</h3>
+{% if gds_files %}
+<div class="mb-3">
+  <h5>GDS Tray</h5>
+  <form method="POST" action="{{ url_for('accounting_routes.create_invoice_from_airfiles', invoice_id=invoice.id) }}">
+    <table class="table table-sm table-bordered">
+      <thead>
+        <tr>
+          <th></th>
+          <th>Agent Code</th>
+          <th>PNR</th>
+          <th>Date</th>
+          <th>File</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for f in gds_files %}
+        <tr>
+          <td><input type="checkbox" name="airfiles" value="{{ f.filename }}"></td>
+          <td>{{ f.agent_code }}</td>
+          <td>{{ f.pnr or '-' }}</td>
+          <td>{{ f.date.strftime('%Y-%m-%d') if f.date else '-' }}</td>
+          <td>{{ f.filename }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <button type="submit" class="btn btn-sm btn-primary">Create Invoice</button>
+  </form>
+</div>
+{% endif %}
 <form method="POST" class="mb-3">
   <div class="row g-2">
     <div class="col-md-3 position-relative">

--- a/app/templates/baseadmin.html
+++ b/app/templates/baseadmin.html
@@ -39,6 +39,7 @@
         <div class="p-3">
           <h5 class="border-bottom pb-2">Menu</h5>
           <a href="{{ url_for('admin_routes.admin_dashboard') }}">Dashboard</a>
+          <a href="{{ url_for('admin_routes.gds_tray') }}">GDS Tray</a>
         </div>
       </nav>
       <main class="col py-4">

--- a/app/templates/gds_tray.html
+++ b/app/templates/gds_tray.html
@@ -1,0 +1,25 @@
+{% extends 'baseadmin.html' %}
+{% block title %}GDS Tray{% endblock %}
+{% block content %}
+<h3>GDS Tray</h3>
+<table class="table table-bordered table-striped">
+  <thead>
+    <tr>
+      <th>Agent Code</th>
+      <th>PNR</th>
+      <th>Date</th>
+      <th>File Name</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for f in files %}
+    <tr>
+      <td>{{ f.agent_code }}</td>
+      <td>{{ f.pnr or '-' }}</td>
+      <td>{{ f.date.strftime('%Y-%m-%d') if f.date else '-' }}</td>
+      <td>{{ f.filename }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- parse AIR files and expose new `gds_tray` admin page
- show link to GDS tray in admin sidebar
- display related GDS files when editing an invoice
- allow selecting files to create invoice (placeholder action)

## Testing
- `python -m py_compile $(git ls-files 'app/**/*.py' 'main.py')`

------
https://chatgpt.com/codex/tasks/task_e_6869152fc7f883238b787449929bc428